### PR TITLE
add 5' flanking sequence used by mompS tool to assess confidence

### DIFF
--- a/el_gato/el_gato.py
+++ b/el_gato/el_gato.py
@@ -1176,6 +1176,19 @@ def assess_allele_conf(bialleles, reads_at_locs, allele_idxs, read_info_dict, re
                         allele.confidence['against'] += 1
                     
                     break
+
+                # alternatively, consider sequence on left flank
+                if "GTTATCAATAAAATG" in mate.seq:
+                    if 16 & mate.flag != 16: 
+                        # If 16 not in the flag
+                        # i.e., read containing 5' flanking seq mapped forward
+                        # meaning mate is from primary locus
+                        allele.confidence["for"] += 1
+                    
+                    else: # Primer indicates secondary allele
+                        allele.confidence['against'] += 1
+                    
+                    break
     
     return alleles_info
 


### PR DESCRIPTION
Includes a 5' sequence, the presence of which in reads indicates that they are from the primary _mompS_ locus. The sequence used in this check is derived from the [mompS](https://github.com/bioinfo-core-BGU/mompS) tool 